### PR TITLE
fix: added supplier info for GET cart item routes

### DIFF
--- a/src/features/carts/carts.service.ts
+++ b/src/features/carts/carts.service.ts
@@ -111,6 +111,9 @@ export class CartsService {
               columns: {
                 product_name: true,
               },
+              with: {
+                supplier: true,
+              },
             },
           },
         },
@@ -142,6 +145,9 @@ export class CartsService {
             product: {
               columns: {
                 product_name: true,
+              },
+              with: {
+                supplier: true,
               },
             },
           },

--- a/src/features/carts/dto/response-cart_item.dto.ts
+++ b/src/features/carts/dto/response-cart_item.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { ResponseSupplierDto } from 'src/features/suppliers/dto/response-supplier.dto';
 
 class ResponseCartItemProductDto {
   @ApiProperty({
@@ -6,6 +7,12 @@ class ResponseCartItemProductDto {
     description: 'Name of the parent product',
   })
   product_name: string;
+
+  @ApiProperty({
+    type: () => ResponseSupplierDto,
+    description: 'Supplier of the product',
+  })
+  supplier: ResponseSupplierDto;
 }
 
 class ResponseCartItemVariantDto {


### PR DESCRIPTION
### Summary

Talked with Richard. None of us realized that we needed to show the suppliers for the carts.

Added supplier information for GET cart/items and cart/items/:variantId routes. Also updated corresponding documentation.

### Linked Issues

closes \#ISSUE_NUMBER

### Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [x] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

### Notes for Reviewers

- n/a
